### PR TITLE
Correct Repository for Debian 11

### DIFF
--- a/00_initial_setup/initial-setup.sh
+++ b/00_initial_setup/initial-setup.sh
@@ -20,7 +20,7 @@ if [ "$DISTRO" == "Debian" ]; then
   elif [ "$OS_VERSION" == "10" ]; then
       sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian buster stable"
   elif [ "$OS_VERSION" == "11" ]; then
-      sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian buster stable"
+      sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian bullseye stable"
   else
       #default tested version
       sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian buster stable"


### PR DESCRIPTION
sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian buster stable" should be sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian bullseye stable"